### PR TITLE
Fix spelling mistake for customer lookup query

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -7,8 +7,10 @@ extend type Query {
   changedCustomers(input: ChangedCustomersQueryInput!): [ChangedCustomer!]!
   "Finds a single customer by customer ID."
   customerById(input: CustomerByIdQueryInput!): Customer
+  "Deprecated: use customerByEncryptedId instead."
+  customerByEncyptedId(input: CustomerByEncryptedIdQueryInput!): Customer @deprecated(reason: "Use customerByEncryptedId instead.")
   "Finds a single customer by encrypted customer ID."
-  customerByEncyptedId(input: CustomerByEncryptedIdQueryInput!): Customer
+  customerByEncryptedId(input: CustomerByEncryptedIdQueryInput!): Customer
   "Finds all customers by the provided email address."
   customersByEmailAddress(input: CustomersByEmailAddressQueryInput!): [Customer!]!
 }

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -335,9 +335,21 @@ module.exports = {
     },
 
     /**
-     *
+     * @deprecated Typo, remove this when associated query is removed from schema.
      */
     async customerByEncyptedId(_, { input }, { apiClient }) {
+      const { id, errorOnNotFound } = input;
+      const response = await apiClient.resource('customer').lookupByEncryptedId({
+        encryptedId: id,
+        errorOnNotFound,
+      });
+      return response.data.Id ? response.data : null;
+    },
+
+    /**
+     *
+     */
+    async customerByEncryptedId(_, { input }, { apiClient }) {
       const { id, errorOnNotFound } = input;
       const response = await apiClient.resource('customer').lookupByEncryptedId({
         encryptedId: id,


### PR DESCRIPTION
Mark query as deprecated, add definition/resolver for properly spelled version. Annotation to remove duplicate resolver when definition is removed as well.