### PR TITLE
Always lowercase email address values

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -79,7 +79,7 @@ type CustomerDemographic {
 type CustomerEmailAddress {
   id: Int! @apiValue
   contactType: EmailAddressContactType! @codeOrType(instance: "EmailContactType", path: "EmailContactType")
-  emailAddress: String! @apiValue
+  emailAddress: String!
   changedDate: DateTime! @apiValue
   statusCode: ContactTypeStatusCode @codeOrType(instance: "ContactTypeStatusCode")
   hashedEmailAddress: String @apiValue

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -166,6 +166,13 @@ module.exports = {
     /**
      *
      */
+    emailAddress({ EmailAddress }) {
+      return EmailAddress.trim().toLowerCase();
+    },
+
+    /**
+     *
+     */
     async optInStatus({ EmailAddress }, _, { loaders }) {
       const r = await loaders.emailAddressOptInStatus.load(EmailAddress);
       return r ? r.data : [];


### PR DESCRIPTION
This ensures consistent return values, as the Omeda API will return cased versions of email addresses (though case is ignored by Omeda when matching)