### PR TITLE
Strip `CDT` suffix from Omeda date strings

### DIFF
--- a/packages/api-client/src/utils/convert-date.js
+++ b/packages/api-client/src/utils/convert-date.js
@@ -2,6 +2,9 @@ const dayjs = require('../dayjs');
 
 module.exports = (value) => {
   if (!value) return null;
-  const date = dayjs.tz(value, 'America/Chicago');
+  let v = value;
+  // some dates include the "CDT" suffix, kill it with fire :)
+  if (/cdt$/i.test(v)) v = v.replace(/cdt$/i, '').trim();
+  const date = dayjs.tz(v, 'America/Chicago');
   return date.isValid(date) ? date : null;
 };


### PR DESCRIPTION
When present, the CDT value causes a date parsing error. Since CDT/CST is already accounted for with all dates, strip this uncessary value.