### PR TITLE
Add extraAddress/mailStop support

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -204,6 +204,8 @@ input RapidCustomerIdentificationMutationInput {
   companyName: String
   "The customer's street address."
   streetAddress: String
+  "The customer's extra address info (apartment/suite/mail stop)."
+  extraAddress: String
   "The customer's city."
   city: String
   "3-character country code"

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -313,6 +313,7 @@ module.exports = {
         title,
         companyName,
         streetAddress,
+        extraAddress,
         city,
         regionCode,
         countryCode,
@@ -360,7 +361,7 @@ module.exports = {
       });
 
       const hasAddress = companyName || regionCode || countryCode || postalCode
-        || streetAddress || city;
+        || streetAddress || city || extraAddress;
 
       const phones = [];
       if (phoneNumber) phones.push({ Number: phoneNumber, PhoneContactType: 200 });
@@ -380,6 +381,7 @@ module.exports = {
             {
               ...(companyName && { Company: companyName }),
               ...(streetAddress && { Street: streetAddress }),
+              ...(extraAddress && { ApartmentMailStop: extraAddress }),
               ...(city && { City: city }),
               ...(regionCode && { RegionCode: regionCode }),
               ...(countryCode && { CountryCode: countryCode }),


### PR DESCRIPTION
Supports saving the extra address info to the apartment/mail stop field on an Omeda customer record.