### PR TITLE
Allow null customer, id, orderId, and encrypted ID

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -140,10 +140,10 @@ type CustomerSubscription {
 }
 
 type RapidCustomerIdentification {
-  id: Int! @apiValue(path: "CustomerId")
-  encryptedCustomerId: String! @apiValue
-  customer: Customer!
-  orderId: Int! @apiValue
+  id: Int @apiValue(path: "CustomerId")
+  encryptedCustomerId: String @apiValue
+  customer: Customer
+  orderId: Int @apiValue
   transactionId: Int! @apiValue
 }
 

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -288,6 +288,7 @@ module.exports = {
      *
      */
     async customer({ CustomerId }, _, { apiClient }) {
+      if (!CustomerId) return null;
       const response = await apiClient.resource('customer').lookupById({
         customerId: CustomerId,
       });


### PR DESCRIPTION
If an input has a process flow hold, the customer and order ids will not be returned. This allows these fields to be nullable in the GraphQL API to account for this condition. Also prevents calling the customer lookup API if no customer ID is present.

```js
{
  Emails: [],
  Url: 'https://ows.omeda.com/webservices/rest/brand/HCL/transaction/60702080/*',
  TransactionId: 60702080
}
```