### PR TITLE
Support sending product subscriptions

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -226,6 +226,9 @@ input RapidCustomerIdentificationMutationInput {
   "Deployment types to assign to, or unassign from, the customer, with opt in/out status."
   deploymentTypes: [RapidCustomerIdentificationDeploymentTypeInput] = []
 
+  "Product subscriptions to assign to the customer."
+  subscriptions: [RapidCustomerIdentificationSubscriptionInput] = []
+
   "Demographics to assign to the customer."
   demographics: [RapidCustomerIdentificationDemographicInput!] = []
   "An optional promo code for tracking the identification acquisition source."
@@ -239,6 +242,13 @@ input RapidCustomerIdentificationDeploymentTypeInput {
   id: Int!
   "Whether the customer opted-in."
   optedIn: Boolean!
+}
+
+input RapidCustomerIdentificationSubscriptionInput {
+  "The product id to subscribe to"
+  id: Int!
+  "Whether the customer should receive this subscription."
+  receive: Boolean!
 }
 
 input RapidCustomerIdentificationDemographicInput {

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -355,16 +355,16 @@ module.exports = {
         });
       }
 
-      const subscriptionMap = subscriptions.reduce((map, { id, receive }) => {
-        map.set(id, receive);
-        return map;
-      }, new Map());
-      const productIds = [...subscriptionMap.keys()];
+      const subscriptionMap = new Map();
+      subscriptions.forEach(({ id, receive }) => {
+        subscriptionMap.set(id, receive);
+        productMap.set(id, receive);
+      });
 
       // Set deployment opt-ins for supplied newsletter product subscriptions
-      if (productIds.length) {
+      if (subscriptionMap.size) {
         const cursor = await repos.brandProduct.find({
-          query: { 'data.Id': { $in: productIds }, 'data.ProductType': 2 },
+          query: { 'data.Id': { $in: [...subscriptionMap.keys()] }, 'data.ProductType': 2 },
           options: { projection: { 'data.Id': 1, 'data.DeploymentTypeId': 1 } },
         });
         await cursor.forEach((doc) => {
@@ -378,7 +378,6 @@ module.exports = {
       }
 
       // Append explicitly provided product subscriptions. Replace if already present
-      subscriptions.forEach(({ id, receive }) => productMap.set(id, receive));
 
       const hasAddress = companyName || regionCode || countryCode || postalCode
         || streetAddress || city || extraAddress;

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -358,8 +358,8 @@ module.exports = {
       const subscriptionMap = new Map();
       subscriptions.forEach(({ id, receive }) => {
         subscriptionMap.set(id, receive);
-        // Append explicitly provided product subscriptions. Replace if already present
-        productMap.set(id, receive);
+        // Append explicitly provided product subscriptions, if not already present.
+        if (!productMap.has(id)) productMap.set(id, receive);
       });
 
       // Set deployment opt-ins for supplied newsletter product subscriptions

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -325,7 +325,7 @@ module.exports = {
 
       const promoCode = input.promoCode ? input.promoCode.trim() : null;
       if (promoCode && promoCode.length > 50) throw new UserInputError('The promo code must be 50 characters or fewer.');
-      const Products = new Map([[input.productId, true]]);
+      const productMap = new Map([[input.productId, true]]);
 
       const deploymentTypeIdMap = input.deploymentTypeIds.reduce((map, id) => {
         map.set(id, true);
@@ -351,7 +351,7 @@ module.exports = {
           const { Id, DeploymentTypeId } = doc.data;
           const optedIn = deploymentTypeOptInMap.get(DeploymentTypeId);
           if (optedIn == null) return;
-          Products.set(Id, optedIn);
+          productMap.set(Id, optedIn);
         });
       }
 
@@ -378,7 +378,7 @@ module.exports = {
       }
 
       // Append explicitly provided product subscriptions. Replace if already present
-      subscriptions.forEach(({ id, receive }) => Products.set(id, receive));
+      subscriptions.forEach(({ id, receive }) => productMap.set(id, receive));
 
       const hasAddress = companyName || regionCode || countryCode || postalCode
         || streetAddress || city || extraAddress;
@@ -390,7 +390,7 @@ module.exports = {
 
       const body = {
         RunProcessor: 1,
-        Products: [...Products].map(([OmedaProductId, Receive]) => ({
+        Products: [...productMap].map(([OmedaProductId, Receive]) => ({
           OmedaProductId,
           Receive: Number(Receive),
         })),

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -320,6 +320,7 @@ module.exports = {
         countryCode,
         postalCode,
         demographics,
+        subscriptions,
       } = input;
 
       const promoCode = input.promoCode ? input.promoCode.trim() : null;
@@ -355,10 +356,15 @@ module.exports = {
         }, new Map());
       })();
 
+        // Append newsletter product subscriptions for each opted-in email deployment
+
       productDeploymentTypeMap.forEach((deploymentTypeId, productId) => {
         const optedIn = deploymentTypeOptInMap.get(deploymentTypeId);
         if (optedIn == null) return;
         Products.push({ OmedaProductId: productId, Receive: Number(optedIn) });
+      // Append explicitly provided product subscriptions
+      subscriptions.forEach(({ id, receive }) => {
+        Products.push({ OmedaProductId: id, Receive: Number(receive) });
       });
 
       const hasAddress = companyName || regionCode || countryCode || postalCode

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -378,7 +378,6 @@ module.exports = {
         });
       }
 
-
       const hasAddress = companyName || regionCode || countryCode || postalCode
         || streetAddress || city || extraAddress;
 

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -358,6 +358,7 @@ module.exports = {
       const subscriptionMap = new Map();
       subscriptions.forEach(({ id, receive }) => {
         subscriptionMap.set(id, receive);
+        // Append explicitly provided product subscriptions. Replace if already present
         productMap.set(id, receive);
       });
 
@@ -377,7 +378,6 @@ module.exports = {
         });
       }
 
-      // Append explicitly provided product subscriptions. Replace if already present
 
       const hasAddress = companyName || regionCode || countryCode || postalCode
         || streetAddress || city || extraAddress;


### PR DESCRIPTION
Now supports sending along explicitly defined [product subscriptions](https://training.omeda.com/knowledge-base/save-customer-and-order/#articleTOC_11) to support product fields within IdentityX.

Refactor Newsletter product handling to simplify flow