### PR TITLE
Support storing behavior attributes

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -287,6 +287,18 @@ input RapidCustomerIdentificationBehaviorInput {
   id: Int!
   "The date the behavior occurred."
   date: DateTime
+  "An array of pre-defined key-values to send with the behavior."
+  attributes: [RapidCustomerIdentificationBehaviorAttributeInput!]! = []
+}
+
+"Input for asisgning a behavior attribute. Id and one of valueId or value must be present."
+input RapidCustomerIdentificationBehaviorAttributeInput {
+  "The Omeda BehaviorAttributeTypeId to assign."
+  id: Int!
+  "The Omeda BehaviorAttribute DefinedValue ID to assign."
+  valueId: Int
+  "The value to assign (for non-pre-defined attributes)."
+  value: String
 }
 
 `;

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -464,9 +464,20 @@ module.exports = {
           })),
         }),
         ...(behaviors.length && {
-          CustomerBehaviors: behaviors.map(({ id, date }) => ({
+          CustomerBehaviors: behaviors.map(({ id, date, attributes }) => ({
             BehaviorId: id,
             BehaviorDate: dayjs(date || new Date()).format('YYYY-MM-DD HH:mm:ss'),
+            ...(attributes.length && {
+              BehaviorAttributes: attributes.map((attr) => {
+                if (!attr.valueId && !attr.value) throw new UserInputError('One of `valueId` or `value` must be specified for behavior attribute!');
+                if (attr.valueId && attr.value) throw new UserInputError('Only one of `valueId` and `value` can be specified for behavior attribute!');
+                return {
+                  BehaviorAttributeTypeId: attr.id,
+                  ...(attr.valueId && { BehaviorAttributeValueId: attr.valueId }),
+                  ...(attr.value && { BehaviorAttributeValue: attr.value }),
+                };
+              }),
+            }),
           })),
         }),
         ...(promoCode && { PromoCode: promoCode }),


### PR DESCRIPTION
Now supports sending `attributes` with behaviors for rapid identification.

```gql
mutation {
  rapidCustomerIdentification(input: {
    email: "foo@bar.com",
    productId: 123,
    behaviors: [
      {
        id: 9,
        attributes: [
          { id: 7, valueId: 1234 },
          { id: 8, value: "1234" },
        ]
      }
    ]
  }
}
```