### PR TITLE
Make product id optional

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -215,7 +215,7 @@ input CustomerExternalIdsInput {
 
 input RapidCustomerIdentificationMutationInput {
   "The product ID to associate with this rapid identification."
-  productId: Int!
+  productId: Int
   "The customer's email address."
   email: String!
   "First name of customer, up to 100 characters long"

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -433,16 +433,19 @@ module.exports = {
       if (faxNumber) phones.push({ Number: faxNumber, PhoneContactType: 240 });
       const body = {
         RunProcessor: 1,
-        Products: [...productMap].map(([OmedaProductId, Receive]) => {
-          const subscription = subscriptions.find((obj) => obj.id === OmedaProductId);
-          return ({
-            OmedaProductId,
-            Receive: Number(Receive),
-            ...(subscription && subscription.requestedVersion && {
-              RequestedVersion: subscription.requestedVersion,
+        ...((productMap && productMap.length)
+          && {
+            Products: [...productMap].map(([OmedaProductId, Receive]) => {
+              const subscription = subscriptions.find((obj) => obj.id === OmedaProductId);
+              return ({
+                OmedaProductId,
+                Receive: Number(Receive),
+                ...(subscription && subscription.requestedVersion && {
+                  RequestedVersion: subscription.requestedVersion,
+                }),
+              });
             }),
-          });
-        }),
+          }),
         Emails: [{ EmailAddress: email }],
         ...(phones.length && { Phones: phones }),
         ...(firstName && { FirstName: firstName }),

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -371,7 +371,7 @@ module.exports = {
 
       const promoCode = input.promoCode ? input.promoCode.trim() : null;
       if (promoCode && promoCode.length > 50) throw new UserInputError('The promo code must be 50 characters or fewer.');
-      const productMap = new Map([[input.productId, true]]);
+      const productMap = new Map([...(input.productId ? [input.productId, true] : [])]);
 
       const deploymentTypeIdMap = input.deploymentTypeIds.reduce((map, id) => {
         map.set(id, true);


### PR DESCRIPTION
Add support to only spread the product when they are present as well

example send to the api and our request to omeda. It was a first name of Brian
<img width="1104" height="524" alt="Screenshot 2025-10-16 at 1 40 04 PM" src="https://github.com/user-attachments/assets/557c8474-34a4-4d16-a2a3-65592ed4531c" />

Update within omeda without sending productId
<img width="1491" height="206" alt="Screenshot 2025-10-16 at 1 40 14 PM" src="https://github.com/user-attachments/assets/ca2e83a9-3984-426a-baee-2a6cbe3d860f" />

