### PR TITLE
Apply BehaviorPromoCode to CustomerBehaviors in rapid identification

### DIFF
--- a/services/graphql/src/definitions/customer.js
+++ b/services/graphql/src/definitions/customer.js
@@ -295,6 +295,8 @@ input RapidCustomerIdentificationBehaviorInput {
   id: Int!
   "The date the behavior occurred."
   date: DateTime
+  "An optional promo code to associate with this specific behavior. Falls back to the top-level promoCode if not set."
+  behaviorPromoCode: String
   "An array of pre-defined key-values to send with the behavior."
   attributes: [RapidCustomerIdentificationBehaviorAttributeInput!]! = []
 }

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -469,10 +469,17 @@ module.exports = {
           })),
         }),
         ...(behaviors.length && {
-          CustomerBehaviors: behaviors.map(({ id, date, behaviorPromoCode, attributes }) => ({
+          CustomerBehaviors: behaviors.map(({
+            id,
+            date,
+            behaviorPromoCode,
+            attributes,
+          }) => ({
             BehaviorId: id,
             BehaviorDate: dayjs(date || new Date()).format('YYYY-MM-DD HH:mm:ss'),
-            ...((behaviorPromoCode || promoCode) && { BehaviorPromoCode: behaviorPromoCode || promoCode }),
+            ...((behaviorPromoCode || promoCode) && {
+              BehaviorPromoCode: behaviorPromoCode || promoCode,
+            }),
             ...(attributes.length && {
               BehaviorAttributes: attributes.map((attr) => {
                 if (!attr.valueId && !attr.value) throw new UserInputError('One of `valueId` or `value` must be specified for behavior attribute!');

--- a/services/graphql/src/resolvers/customer.js
+++ b/services/graphql/src/resolvers/customer.js
@@ -469,9 +469,10 @@ module.exports = {
           })),
         }),
         ...(behaviors.length && {
-          CustomerBehaviors: behaviors.map(({ id, date, attributes }) => ({
+          CustomerBehaviors: behaviors.map(({ id, date, behaviorPromoCode, attributes }) => ({
             BehaviorId: id,
             BehaviorDate: dayjs(date || new Date()).format('YYYY-MM-DD HH:mm:ss'),
+            ...((behaviorPromoCode || promoCode) && { BehaviorPromoCode: behaviorPromoCode || promoCode }),
             ...(attributes.length && {
               BehaviorAttributes: attributes.map((attr) => {
                 if (!attr.valueId && !attr.value) throw new UserInputError('One of `valueId` or `value` must be specified for behavior attribute!');


### PR DESCRIPTION
## Summary

- Per Omeda's API docs, `PromoCode` on the `Customer Behavior Element` has been deprecated in favor of `BehaviorPromoCode`
- The resolver now sets `BehaviorPromoCode` on each behavior in the `CustomerBehaviors` array, using the top-level `promoCode` as the value (with optional per-behavior override via a new `behaviorPromoCode` field on the behavior input)
- Added optional `behaviorPromoCode: String` to `RapidCustomerIdentificationBehaviorInput` — callers can pass a behavior-specific promo code; if absent, falls back to the top-level `promoCode`
- Top-level `PromoCode` field is preserved for backwards compatibility

## Test plan

- [x] Trigger a login link send on a site with `omedaPromoCodePrefix` configured and confirm the promo code appears on the resulting customer behavior in the Omeda portal
- [x] Verify existing behavior (no `behaviorPromoCode` on input) still correctly falls back to top-level `promoCode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)